### PR TITLE
fix: change guidance_scale default to 7.0 to align with original

### DIFF
--- a/src/request.cpp
+++ b/src/request.cpp
@@ -27,7 +27,7 @@ void request_init(AceRequest * r) {
     r->lm_negative_prompt = "";
     r->audio_codes        = "";
     r->inference_steps    = 8;
-    r->guidance_scale     = 1.0f;
+    r->guidance_scale     = 7.0f;
     r->shift              = 3.0f;
 }
 


### PR DESCRIPTION
Should https://github.com/ServeurpersoCom/acestep.cpp/blob/3738e92cf3da39690bb45328135376375c2f851b/src/dit-sampler.h#L133 be updated as well?