### PR TITLE
Fix conditions for packaging binaries for MacOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           fi
 
       - name: Package binaries (Linux)
-        if: runner.os != 'Windows'
+        if: runner.os == 'Linux'
         run: |
           mkdir -p dist
           cp build/ace-qwen3 build/dit-vae build/ace-understand \
@@ -114,7 +114,7 @@ jobs:
           tar -C dist -czf "acestep-${{ matrix.name }}.tar.gz" .
 
       - name: Package binaries (macOS)
-        if: runner.os != 'macOS'
+        if: runner.os == 'macOS'
         run: |
           mkdir -p dist
           cp build/ace-qwen3 build/dit-vae build/ace-understand \


### PR DESCRIPTION
Required fix to correctly handle each condition (bug derived from excluding the windows builds temporarily)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline accuracy by ensuring platform-specific binaries are packaged only on their respective operating systems, resulting in more reliable release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->