### PR TITLE
GH Fix: include osx libraries, add ccache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq cmake build-essential ${{ matrix.apt_extra || '' }}
 
+      - name: ccache
+        if: runner.os != 'Windows'
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          create-symlink: true
+          key: ${{ github.job }}-${{ matrix.os }}
+
       - name: Install CUDA toolkit (Linux)
         uses: Jimver/cuda-toolkit@v0.2.30
         if: matrix.install_cuda == true


### PR DESCRIPTION
Action fix in preparation for future releases, nothing urgent 

* Added a `ccache` step to the workflow to speed up linux builds
* Include dynamic libraries in OSX releases