### PR TITLE
fix: apply "model." prefix only for lm models and fix UTF-8 decoding of vocab.json/merges.txt

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -35,7 +35,8 @@ def find_sf_files(model_dir):
         return [single]
     index = os.path.join(model_dir, "model.safetensors.index.json")
     if os.path.exists(index):
-        idx = json.load(open(index))
+        with open(index, "r", encoding="utf-8") as f:
+            idx = json.load(f)
         shards = sorted(set(idx["weight_map"].values()))
         return [os.path.join(model_dir, s) for s in shards]
     diffusers = os.path.join(model_dir, "diffusion_pytorch_model.safetensors")
@@ -202,7 +203,8 @@ def convert_model(name, model_dir, output_path, model_type):
         log(tag, "skip %s: no config.json" % name)
         return False
 
-    cfg = json.load(open(cfg_path))
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
     sf_files = find_sf_files(model_dir)
     if not sf_files:
         log(tag, "skip %s: no safetensors" % name)


### PR DESCRIPTION
This PR adjusts the ACE‑Step Safetensors → GGUF converter to:

- Apply the `"model."` prefix normalization of tensor names only for `lm`‑type models (`acestep-lm`), leaving DiT, text encoder, and VAE checkpoints unchanged.  
- Fix a `UnicodeDecodeError` when reading `vocab.json` and `merges.txt` on Windows by explicitly opening them with UTF‑8 encoding instead of relying on the system default (`cp1251`).  

These changes allow the script to correctly handle ACE‑Step LM checkpoints (including `acestep-5Hz-lm-*`) while remaining compatible with other ACE‑Step model types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model conversion robustness improved: tensor name normalization now avoids duplicate prefixes and correctly handles different model types (language models, text encoders, VAEs), preventing naming conflicts during conversion.
  * Tokenizer ingestion hardened: tokenizer and config files are read more safely with proper encoding and resilient parsing to prevent import errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->