### PR TITLE
Fix repository URL in README for cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Alternative: `./models.sh` downloads the default set automatically (needs `pip i
 ## Build
 
 ```
-git clone --recurse-submodules https://github.com/Serveurperso/acestep.cpp
+git clone --recurse-submodules https://github.com/ServeurpersoCom/acestep.cpp.git
 cd acestep.cpp
 ```
 


### PR DESCRIPTION
corrected the repo url in readme docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions with the correct repository URL for project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->