### PR TITLE
fix: link ws2_32 on Windows/MinGW for httplib socket symbols

### DIFF
--- a/vendor/cpp-httplib/CMakeLists.txt
+++ b/vendor/cpp-httplib/CMakeLists.txt
@@ -9,3 +9,7 @@ if(MSVC)
 else()
     target_compile_options(httplib PRIVATE -w)
 endif()
+
+if(WIN32)
+    target_link_libraries(httplib PRIVATE ws2_32)
+endif()


### PR DESCRIPTION
The #pragma comment(lib, "ws2_32.lib") in httplib.h is guarded by #if defined(_MSC_VER), so it is silently skipped when compiling with MinGW/GCC.
This causes unresolved WinSock2 symbols at link time for any target consuming httplib (e.g. ace-server).
Add the missing ws2_32 link dependency in the CMake build, matching the same pattern already used by ggml-rpc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build configuration to include required system library dependency for proper compilation on the Windows platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->