### PR TITLE
core: widen the cancel callback into an AceProgress report+cancel callback

### DIFF
--- a/src/audio-io.h
+++ b/src/audio-io.h
@@ -5,6 +5,7 @@
 // All functions use planar stereo float: [L: T samples][R: T samples].
 // Part of acestep.cpp. MIT license.
 
+#include "progress.h"
 #include "task-types.h"
 
 #include <algorithm>
@@ -580,12 +581,7 @@ static bool audio_write_wav(const char * path, const float * audio, int T_audio,
 // audio_encode_mp3 is the core: encode planar stereo to MP3 in memory.
 // Does NOT normalize - caller is responsible (audio_write does it).
 // Returns empty string on failure.
-static std::string audio_encode_mp3(const float * audio,
-                                    int           T_audio,
-                                    int           sr,
-                                    int           kbps,
-                                    bool (*cancel)(void *) = nullptr,
-                                    void * cancel_data     = nullptr) {
+static std::string audio_encode_mp3(const float * audio, int T_audio, int sr, int kbps, AceProgress progress = {}) {
     const float * enc_audio = audio;
     int           enc_T     = T_audio;
     int           enc_sr    = sr;
@@ -657,8 +653,10 @@ static std::string audio_encode_mp3(const float * audio,
 
     std::vector<std::string> results(n_threads);
 
-    // worker: encode one chunk with a private encoder instance.
-    // feeds 1-second sub-chunks for cancel responsiveness.
+    // worker: encode one chunk with a private encoder instance, in 1-second
+    // sub-chunks to bound the per-iteration scratch buffer. (Cancel is polled
+    // once after the join, not per sub-chunk -- progress.fn is not called from
+    // these worker threads.)
     auto worker = [&](int tid) {
         int chunk_start = ranges[tid].start;
         int chunk_end   = ranges[tid].end;
@@ -705,13 +703,14 @@ static std::string audio_encode_mp3(const float * audio,
             e->out_written = 0;
         }
 
-        // encode real chunk
+        // encode real chunk. No cancel poll here: this runs in fork-join worker
+        // threads and progress.fn is not required to be thread-safe (it may be
+        // recording progress), so it is only ever called from the single-threaded
+        // post-join check below. MP3 encode of already-generated audio is fast, so
+        // the responsiveness cost of not bailing mid-chunk is negligible.
         int chunk_len = chunk_end - chunk_start;
         int sub       = enc_sr;  // ~1 second
         for (int p = 0; p < chunk_len; p += sub) {
-            if (cancel && cancel(cancel_data)) {
-                break;
-            }
             int len = (p + sub <= chunk_len) ? sub : (chunk_len - p);
 
             float * buf = (float *) malloc((size_t) len * 2 * sizeof(float));
@@ -753,7 +752,7 @@ static std::string audio_encode_mp3(const float * audio,
 
     free(resampled);
 
-    if (cancel && cancel(cancel_data)) {
+    if (ace_cancelled(progress, ACE_STAGE_MP3)) {
         fprintf(stderr, "[MP3] Cancelled\n");
         return "";
     }

--- a/src/dit-sampler.h
+++ b/src/dit-sampler.h
@@ -8,6 +8,7 @@
 #include "dit-graph.h"
 #include "dit.h"
 #include "dwt-haar.h"
+#include "progress.h"
 #include "solvers/solver-registry.h"
 #include "static-graph.h"
 
@@ -144,10 +145,9 @@ static int dit_ggml_generate(DiTGGML *           model,
                              const DebugDumper * dbg            = nullptr,
                              const float *       context_switch = nullptr,
                              int                 cover_steps    = -1,
-                             bool (*cancel)(void *)             = nullptr,
-                             void *          cancel_data        = nullptr,
-                             const int *     real_enc_S         = nullptr,
-                             const float *   enc_switch         = nullptr,
+                             AceProgress         progress       = {},
+                             const int *         real_enc_S     = nullptr,
+                             const float *       enc_switch     = nullptr,
                              const int *     real_enc_S_switch  = nullptr,
                              const int64_t * seeds              = nullptr,
                              bool            use_batch_cfg      = true,
@@ -412,8 +412,14 @@ static int dit_ggml_generate(DiTGGML *           model,
 
     // Flow matching loop
     bool switched_cover = false;
+    if (ace_cancelled(progress,
+                      ACE_STAGE_DIT)) {  // honour a cancel before the loop; the loop's step-0 poll sizes the bar
+        fprintf(stderr, "[DiT] Cancelled at step 0/%d\n", num_steps);
+        ggml_free(ctx);
+        return -1;
+    }
     for (int step = 0; step < num_steps; step++) {
-        if (cancel && cancel(cancel_data)) {
+        if (ace_progress(progress, ACE_STAGE_DIT, step, num_steps)) {
             fprintf(stderr, "[DiT] Cancelled at step %d/%d\n", step, num_steps);
             static_graph_release(&dit_graph, model->sched);
             ggml_free(ctx);

--- a/src/pipeline-lm.cpp
+++ b/src/pipeline-lm.cpp
@@ -57,8 +57,7 @@ static std::vector<std::string> generate_phase1_batch(Qwen3LM *                 
                                                       float                                 cfg_scale         = 1.0f,
                                                       const std::vector<std::vector<int>> * unconds           = nullptr,
                                                       bool                                  stop_at_reasoning = false,
-                                                      bool (*cancel)(void *)                                  = nullptr,
-                                                      void * cancel_data = nullptr) {
+                                                      AceProgress                              progress       = {}) {
     int  N       = (int) prompts.size();
     int  V       = m->cfg.vocab_size;
     bool use_cfg = cfg_scale > 1.0f && unconds && !unconds->empty();
@@ -187,8 +186,13 @@ static std::vector<std::string> generate_phase1_batch(Qwen3LM *                 
         }
     }
 
+    if (ace_cancelled(progress,
+                      ACE_STAGE_LM)) {  // honour a cancel before the loop; the loop's step-0 poll sizes the bar
+        fprintf(stderr, "[LM-Phase1] Cancelled at step 0\n");
+        return {};
+    }
     for (int step = 0; step < max_new_tokens && n_active > 0; step++) {
-        if (cancel && cancel(cancel_data)) {
+        if (ace_progress(progress, ACE_STAGE_LM, step, max_new_tokens)) {
             fprintf(stderr, "[LM-Phase1] Cancelled at step %d\n", step);
             return {};
         }
@@ -297,8 +301,7 @@ static std::vector<std::string> run_phase2_batch(Qwen3LM *                      
                                                  float                          cfg_scale,
                                                  const char *                   negative_prompt,
                                                  bool                           use_batch_cfg,
-                                                 bool (*cancel)(void *),
-                                                 void * cancel_data) {
+                                                 AceProgress                    progress) {
     int  N       = (int) aces.size();
     int  V       = m->cfg.vocab_size;
     bool use_cfg = cfg_scale > 1.0f;
@@ -449,8 +452,13 @@ static std::vector<std::string> run_phase2_batch(Qwen3LM *                      
         }
     }
 
+    if (ace_cancelled(progress,
+                      ACE_STAGE_LM)) {  // honour a cancel before the loop; the loop's step-0 poll sizes the bar
+        fprintf(stderr, "[LM-Phase2] Cancelled at step 0\n");
+        return {};
+    }
     for (int step = 0; step < max_tokens && n_active > 0; step++) {
-        if (cancel && cancel(cancel_data)) {
+        if (ace_progress(progress, ACE_STAGE_LM, step, max_tokens)) {
             fprintf(stderr, "[LM-Phase2] Cancelled at step %d\n", step);
             return {};
         }
@@ -611,9 +619,8 @@ int ace_lm_generate(AceLm *            ctx,
                     AceRequest *       out,
                     const char *       dump_logits,
                     const char *       dump_tokens,
-                    bool (*cancel)(void *),
-                    void * cancel_data,
-                    int    mode) {
+                    AceProgress        progress,
+                    int                mode) {
     if (!ctx || !reqs || !out || n_req < 1) {
         return -1;
     }
@@ -814,7 +821,7 @@ int ace_lm_generate(AceLm *            ctx,
 
         auto phase1_texts = generate_phase1_batch(
             model, bpe, prompts, 2048, temperature, fill_top_p, fill_top_k, seeds, fsm_template ? &fsms : nullptr,
-            gen_lyrics, fill_cfg, unconds.empty() ? nullptr : &unconds, !gen_lyrics, cancel, cancel_data);
+            gen_lyrics, fill_cfg, unconds.empty() ? nullptr : &unconds, !gen_lyrics, progress);
         if (phase1_texts.empty()) {
             return -1;
         }
@@ -885,7 +892,7 @@ int ace_lm_generate(AceLm *            ctx,
                 mode == LM_MODE_INSPIRE ? "Inspire" : "Format");
     } else if (!user_has_codes) {
         batch_codes = run_phase2_batch(model, *bpe, aces, temperature, top_p, top_k, seeds, cfg_scale, neg_prompt,
-                                       ctx->params.use_batch_cfg, cancel, cancel_data);
+                                       ctx->params.use_batch_cfg, progress);
         if (batch_codes.empty()) {
             return -1;
         }

--- a/src/pipeline-lm.h
+++ b/src/pipeline-lm.h
@@ -5,6 +5,7 @@
 // pipeline acquires the Qwen3 LM, BPE tokenizer and FSM template from the
 // store and releases the LM through RAII before returning.
 
+#include "progress.h"
 #include "request.h"
 #include "task-types.h"
 
@@ -37,7 +38,8 @@ AceLm * ace_lm_load(ModelStore * store, const AceLmParams * params);
 // out[n_req] allocated by caller, filled with enriched copies of each request.
 // mode: LM_MODE_GENERATE (full), LM_MODE_INSPIRE (no codes), LM_MODE_FORMAT (no codes).
 // dump_logits/dump_tokens: debug output paths (NULL to disable).
-// cancel/cancel_data: abort callback, polled between tokens. NULL = never cancel.
+// progress: abort + progress callback, polled between tokens (ACE_STAGE_LM).
+// Default {} = never cancel, no progress.
 // Returns 0 on success, -1 on error or cancellation.
 int ace_lm_generate(AceLm *            ctx,
                     const AceRequest * reqs,
@@ -45,9 +47,8 @@ int ace_lm_generate(AceLm *            ctx,
                     AceRequest *       out,
                     const char *       dump_logits,
                     const char *       dump_tokens,
-                    bool (*cancel)(void *) = nullptr,
-                    void * cancel_data     = nullptr,
-                    int    mode            = LM_MODE_GENERATE);
+                    AceProgress        progress = {},
+                    int                mode     = LM_MODE_GENERATE);
 
 void ace_lm_free(AceLm * ctx);
 

--- a/src/pipeline-synth-ops.cpp
+++ b/src/pipeline-synth-ops.cpp
@@ -123,7 +123,8 @@ int ops_encode_src(const AceSynth * ctx,
                    int              src_len,
                    const float *    src_latents,
                    int              src_T_latent,
-                   SynthState &     s) {
+                   SynthState &     s,
+                   AceProgress      progress) {
     // Cover mode: ingest source either as pre-encoded latents (zero VAE work)
     // or by acquiring the VAE encoder and running it on src_audio. When both
     // are provided latents win: they were either produced by a previous run
@@ -153,9 +154,16 @@ int ops_encode_src(const AceSynth * ctx,
         s.cover_latents.resize(max_T_lat * 64);
 
         s.T_cover = vae_enc_encode_tiled(vae_enc, src_audio, T_audio, s.cover_latents.data(), max_T_lat,
-                                         ctx->params.vae_chunk, ctx->params.vae_overlap);
+                                         ctx->params.vae_chunk, ctx->params.vae_overlap, progress);
         if (s.T_cover < 0) {
-            fprintf(stderr, "[Encode-Src] FATAL: encode failed\n");
+            // -1 is both cancel and failure; both abort here (unlike the timbre
+            // path, which tolerates a failure by falling back to silence), so
+            // this only sharpens the diagnostic.
+            if (ace_cancelled(progress, ACE_STAGE_VAE_ENCODE)) {
+                fprintf(stderr, "[Encode-Src] Cancelled\n");
+            } else {
+                fprintf(stderr, "[Encode-Src] FATAL: encode failed\n");
+            }
             return -1;
         }
         s.cover_latents.resize(s.T_cover * 64);
@@ -342,12 +350,16 @@ int ops_resolve_T(const AceSynth * ctx, SynthState & s) {
     return 0;
 }
 
-void ops_encode_timbre(const AceSynth * ctx,
-                       const float *    ref_audio,
-                       int              ref_len,
-                       const float *    ref_latents,
-                       int              ref_T_latent,
-                       SynthState &     s) {
+// 0 on success (including the deliberate fall-back to silence when a ref_audio
+// encode *fails*), -1 if the run was cancelled during the ref encode -- so the
+// caller aborts rather than silently generating with silence timbre.
+int ops_encode_timbre(const AceSynth * ctx,
+                      const float *    ref_audio,
+                      int              ref_len,
+                      const float *    ref_latents,
+                      int              ref_T_latent,
+                      SynthState &     s,
+                      AceProgress      progress) {
     // Timbre features from ref_audio or ref_latents (independent of src).
     // Two paths converge into s.timbre_feats: pre-encoded latents skip the
     // VAE encoder entirely, raw audio takes the encoder path. Latents win
@@ -358,7 +370,7 @@ void ops_encode_timbre(const AceSynth * ctx,
         s.timbre_feats.assign(ref_latents, ref_latents + (size_t) ref_T_latent * 64);
         fprintf(stderr, "[Encode-Timbre] Latents in: %d frames (%.1fs), VAE encode skipped\n", ref_T_latent,
                 (float) ref_T_latent / 25.0f);
-        return;
+        return 0;
     }
     if (ref_audio && ref_len > 0) {
         s.timer.reset();
@@ -367,15 +379,22 @@ void ops_encode_timbre(const AceSynth * ctx,
             fprintf(stderr, "[Encode-Timbre] WARNING: store_require_vae_enc failed, using silence\n");
             s.S_ref_timbre = 1;
             s.timbre_feats.assign(ctx->meta->silence_full.data(), ctx->meta->silence_full.data() + 64);
-            return;
+            return 0;
         }
         ModelHandle ref_vae_guard(ctx->store, ref_vae);
 
         int                max_T_ref = (ref_len / 1920) + 64;
         std::vector<float> ref_lat_buf(max_T_ref * 64);
         int                T_ref = vae_enc_encode_tiled(ref_vae, ref_audio, ref_len, ref_lat_buf.data(), max_T_ref,
-                                                        ctx->params.vae_chunk, ctx->params.vae_overlap);
+                                                        ctx->params.vae_chunk, ctx->params.vae_overlap, progress);
         if (T_ref < 0) {
+            // vae_enc_encode_tiled returns -1 for both a cancel and a real encode
+            // failure. A cancel must abort; only a genuine failure falls back to
+            // silence (which the whole point of this path -- Cover import -- can
+            // tolerate). Re-poll to tell them apart (cancel is level-triggered).
+            if (ace_cancelled(progress, ACE_STAGE_VAE_ENCODE)) {
+                return -1;
+            }
             fprintf(stderr, "[Encode-Timbre] WARNING: ref_audio encode failed, using silence\n");
             s.S_ref_timbre = 1;
             s.timbre_feats.assign(ctx->meta->silence_full.data(), ctx->meta->silence_full.data() + 64);
@@ -389,6 +408,7 @@ void ops_encode_timbre(const AceSynth * ctx,
         s.S_ref_timbre = 1;
         s.timbre_feats.assign(ctx->meta->silence_full.data(), ctx->meta->silence_full.data() + 64);
     }
+    return 0;
 }
 
 // Per-batch CPU-resident forward from the text encoder.
@@ -419,8 +439,8 @@ static void build_prompt_strings(const AceRequest &  rb,
     char metas_b[512];
     snprintf(metas_b, sizeof(metas_b), "- bpm: %s\n- timesignature: %s\n- keyscale: %s\n- duration: %d seconds\n",
              bpm_b, timesig_b, keyscale_b, (int) duration);
-    text_out = std::string("# Instruction\n") + instruction + "\n\n" + "# Caption\n" + rb.caption + "\n\n" +
-               "# Metas\n" + metas_b + "<|endoftext|>\n";
+    text_out  = std::string("# Instruction\n") + instruction + "\n\n" + "# Caption\n" + rb.caption + "\n\n" +
+                "# Metas\n" + metas_b + "<|endoftext|>\n";
     lyric_out = std::string("# Languages\n") + language_b + "\n\n# Lyric\n" + rb.lyrics + "<|endoftext|>";
 }
 
@@ -825,7 +845,7 @@ void ops_init_noise(const AceSynth * ctx, const AceRequest * reqs, int batch_n, 
             s.num_steps, batch_n, s.use_source_context ? " (cover)" : "");
 }
 
-int ops_dit_generate(const AceSynth * ctx, int batch_n, SynthState & s, bool (*cancel)(void *), void * cancel_data) {
+int ops_dit_generate(const AceSynth * ctx, int batch_n, SynthState & s, AceProgress progress) {
     DiTGGML * dit = store_require_dit(ctx->store, ctx->dit_key);
     if (!dit) {
         fprintf(stderr, "[DiT-Generate] FATAL: store_require_dit failed\n");
@@ -840,7 +860,7 @@ int ops_dit_generate(const AceSynth * ctx, int batch_n, SynthState & s, bool (*c
     int dit_rc = dit_ggml_generate(
         dit, s.noise.data(), s.context.data(), s.enc_hidden.data(), s.enc_S, s.T, batch_n, s.num_steps,
         s.schedule.data(), s.output.data(), s.guidance_scale, &s.dbg,
-        s.context_silence.empty() ? nullptr : s.context_silence.data(), s.cover_steps, cancel, cancel_data,
+        s.context_silence.empty() ? nullptr : s.context_silence.data(), s.cover_steps, progress,
         s.per_enc_S.data(), s.enc_hidden_nc.empty() ? nullptr : s.enc_hidden_nc.data(),
         s.per_enc_S_nc_final.empty() ? nullptr : s.per_enc_S_nc_final.data(), s.seeds.data(), ctx->params.use_batch_cfg,
         s.rr.dcw_scaler, s.rr.dcw_high_scaler, s.rr.dcw_mode.c_str(), s.rr.solver.c_str(), s.rr.stork_substeps);
@@ -864,12 +884,7 @@ int ops_dit_generate(const AceSynth * ctx, int batch_n, SynthState & s, bool (*c
     return 0;
 }
 
-int ops_vae_decode(const AceSynth * ctx,
-                   int              batch_n,
-                   AceAudio *       out,
-                   SynthState &     s,
-                   bool (*cancel)(void *),
-                   void * cancel_data) {
+int ops_vae_decode(const AceSynth * ctx, int batch_n, AceAudio * out, SynthState & s, AceProgress progress) {
     VAEGGML * vae = store_require_vae_dec(ctx->store, ctx->vae_dec_key);
     if (!vae) {
         fprintf(stderr, "[VAE-Decode] FATAL: store_require_vae_dec failed\n");
@@ -904,9 +919,9 @@ int ops_vae_decode(const AceSynth * ctx,
 
         s.timer.reset();
         int T_audio = vae_ggml_decode_tiled(vae, dit_out, T_latent, audio.data(), T_audio_max, ctx->params.vae_chunk,
-                                            ctx->params.vae_overlap, cancel, cancel_data);
+                                            ctx->params.vae_overlap, progress);
         if (T_audio < 0) {
-            if (cancel && cancel(cancel_data)) {
+            if (ace_cancelled(progress, ACE_STAGE_VAE_DECODE)) {
                 fprintf(stderr, "[VAE-Decode Batch%d] Cancelled\n", b);
                 return -1;
             }

--- a/src/pipeline-synth-ops.h
+++ b/src/pipeline-synth-ops.h
@@ -7,6 +7,7 @@
 // AceSynth are defined in pipeline-synth-impl.h.
 
 #include "pipeline-synth.h"
+#include "progress.h"
 
 struct AceSynth;
 struct SynthState;
@@ -19,7 +20,8 @@ int ops_encode_src(const AceSynth * ctx,
                    int              src_len,
                    const float *    src_latents,
                    int              src_T_latent,
-                   SynthState &     s);
+                   SynthState &     s,
+                   AceProgress      progress = {});
 
 // FSQ roundtrip on cover_latents (cover mode only).
 void ops_fsq_roundtrip(const AceSynth * ctx, SynthState & s);
@@ -34,12 +36,13 @@ void ops_build_schedule(SynthState & s);
 int ops_resolve_T(const AceSynth * ctx, SynthState & s);
 
 // Encode timbre from ref_audio via VAE. Sets s.timbre_feats and s.S_ref_timbre.
-void ops_encode_timbre(const AceSynth * ctx,
-                       const float *    ref_audio,
-                       int              ref_len,
-                       const float *    ref_latents,
-                       int              ref_T_latent,
-                       SynthState &     s);
+int ops_encode_timbre(const AceSynth * ctx,
+                      const float *    ref_audio,
+                      int              ref_len,
+                      const float *    ref_latents,
+                      int              ref_T_latent,
+                      SynthState &     s,
+                      AceProgress      progress = {});
 
 // Per-batch text + lyric encoding (main pass + optional non-cover pass).
 // Stacks results into s.enc_hidden / s.enc_hidden_nc.
@@ -55,16 +58,11 @@ void ops_build_context_silence(const AceSynth * ctx, int batch_n, SynthState & s
 void ops_init_noise(const AceSynth * ctx, const AceRequest * reqs, int batch_n, SynthState & s);
 
 // Run the DiT denoising loop.
-int ops_dit_generate(const AceSynth * ctx, int batch_n, SynthState & s, bool (*cancel)(void *), void * cancel_data);
+int ops_dit_generate(const AceSynth * ctx, int batch_n, SynthState & s, AceProgress progress);
 
 // Phase 2 primitive.
 
 // Latent splice for repaint/lego (kept generated frames inside [t0, t1),
 // source latents elsewhere) followed by VAE decode for every batch item.
 // Returns 0 on success, -1 on error/cancel.
-int ops_vae_decode(const AceSynth * ctx,
-                   int              batch_n,
-                   AceAudio *       out,
-                   SynthState &     s,
-                   bool (*cancel)(void *),
-                   void * cancel_data);
+int ops_vae_decode(const AceSynth * ctx, int batch_n, AceAudio * out, SynthState & s, AceProgress progress);

--- a/src/pipeline-synth.cpp
+++ b/src/pipeline-synth.cpp
@@ -248,7 +248,8 @@ static bool pinned_encode_src_and_timbre(AceSynth *    ctx,
                                          int           ref_len,
                                          const float * ref_latents,
                                          int           ref_T_latent,
-                                         SynthState &  s) {
+                                         SynthState &  s,
+                                         AceProgress   progress) {
     bool have_src_audio   = src_audio && src_len > 0;
     bool have_src_latents = src_latents && src_T_latent > 0;
     bool have_src         = have_src_audio || have_src_latents;
@@ -257,7 +258,9 @@ static bool pinned_encode_src_and_timbre(AceSynth *    ctx,
     bool have_ref         = have_ref_audio || have_ref_latents;
     if (!have_src && !have_ref) {
         // Neither encode touches the GPU: timbre takes the silence path.
-        ops_encode_timbre(ctx, NULL, 0, NULL, 0, s);
+        if (ops_encode_timbre(ctx, NULL, 0, NULL, 0, s, progress) != 0) {
+            return false;
+        }
         return true;
     }
     bool        need_vae_pin = (have_src_audio || have_ref_audio);
@@ -267,23 +270,20 @@ static bool pinned_encode_src_and_timbre(AceSynth *    ctx,
         return false;
     }
     if (have_src) {
-        if (ops_encode_src(ctx, src_audio, src_len, src_latents, src_T_latent, s) != 0) {
+        if (ops_encode_src(ctx, src_audio, src_len, src_latents, src_T_latent, s, progress) != 0) {
             return false;
         }
     }
-    ops_encode_timbre(ctx, ref_audio, ref_len, ref_latents, ref_T_latent, s);
+    if (ops_encode_timbre(ctx, ref_audio, ref_len, ref_latents, ref_T_latent, s, progress) != 0) {
+        return false;
+    }
     return true;
 }
 
 // Common tail every task ends with once its inputs are encoded and flags are
 // posed: resolve params, resolve T, build schedule, encode text, build
 // context, init noise, run DiT. Returns 0 on success, -1 on error/cancel.
-static int run_tail(AceSynth *         ctx,
-                    const AceRequest * reqs,
-                    int                batch_n,
-                    SynthState &       s,
-                    bool (*cancel)(void *),
-                    void * cancel_data) {
+static int run_tail(AceSynth * ctx, const AceRequest * reqs, int batch_n, SynthState & s, AceProgress progress) {
     if (ops_resolve_params(ctx, reqs, batch_n, s) != 0) {
         return -1;
     }
@@ -299,7 +299,7 @@ static int run_tail(AceSynth *         ctx,
     }
     ops_build_context_silence(ctx, batch_n, s);
     ops_init_noise(ctx, reqs, batch_n, s);
-    if (ops_dit_generate(ctx, batch_n, s, cancel, cancel_data) != 0) {
+    if (ops_dit_generate(ctx, batch_n, s, progress) != 0) {
         return -1;
     }
     return 0;
@@ -314,8 +314,7 @@ static AceSynthJob * run_text2music(AceSynth *         ctx,
                                     const float *      ref_latents,
                                     int                ref_T_latent,
                                     int                batch_n,
-                                    bool (*cancel)(void *),
-                                    void * cancel_data) {
+                                    AceProgress        progress) {
     AceSynthJob * job    = alloc_job(ctx, reqs, batch_n);
     SynthState &  s      = job->state;
     // audio_codes from the LM produce a latent context; empty codes fall back
@@ -324,11 +323,12 @@ static AceSynthJob * run_text2music(AceSynth *         ctx,
     s.use_source_context = !reqs[0].audio_codes.empty();
     s.instruction_str    = s.use_source_context ? DIT_INSTR_COVER : DIT_INSTR_TEXT2MUSIC;
 
-    if (!pinned_encode_src_and_timbre(ctx, NULL, 0, NULL, 0, ref_audio, ref_len, ref_latents, ref_T_latent, s)) {
+    if (!pinned_encode_src_and_timbre(ctx, NULL, 0, NULL, 0, ref_audio, ref_len, ref_latents, ref_T_latent, s,
+                                      progress)) {
         delete job;
         return NULL;
     }
-    if (run_tail(ctx, reqs, batch_n, s, cancel, cancel_data) != 0) {
+    if (run_tail(ctx, reqs, batch_n, s, progress) != 0) {
         delete job;
         return NULL;
     }
@@ -348,8 +348,7 @@ static AceSynthJob * run_cover(AceSynth *         ctx,
                                const float *      ref_latents,
                                int                ref_T_latent,
                                int                batch_n,
-                               bool (*cancel)(void *),
-                               void * cancel_data) {
+                               AceProgress        progress) {
     bool have_src = (src_audio && src_len > 0) || (src_latents && src_T_latent > 0);
     if (!have_src) {
         fprintf(stderr, "[Synth-Run] ERROR: task 'cover' requires source audio or latents\n");
@@ -361,7 +360,7 @@ static AceSynthJob * run_cover(AceSynth *         ctx,
     s.instruction_str    = DIT_INSTR_COVER;
 
     if (!pinned_encode_src_and_timbre(ctx, src_audio, src_len, src_latents, src_T_latent, ref_audio, ref_len,
-                                      ref_latents, ref_T_latent, s)) {
+                                      ref_latents, ref_T_latent, s, progress)) {
         delete job;
         return NULL;
     }
@@ -371,7 +370,7 @@ static AceSynthJob * run_cover(AceSynth *         ctx,
     s.noise_blend_latents = s.cover_latents;
     ops_fsq_roundtrip(ctx, s);
 
-    if (run_tail(ctx, reqs, batch_n, s, cancel, cancel_data) != 0) {
+    if (run_tail(ctx, reqs, batch_n, s, progress) != 0) {
         delete job;
         return NULL;
     }
@@ -392,8 +391,7 @@ static AceSynthJob * run_cover_nofsq(AceSynth *         ctx,
                                      const float *      ref_latents,
                                      int                ref_T_latent,
                                      int                batch_n,
-                                     bool (*cancel)(void *),
-                                     void * cancel_data) {
+                                     AceProgress        progress) {
     bool have_src = (src_audio && src_len > 0) || (src_latents && src_T_latent > 0);
     if (!have_src) {
         fprintf(stderr, "[Synth-Run] ERROR: task 'cover-nofsq' requires source audio or latents\n");
@@ -405,11 +403,11 @@ static AceSynthJob * run_cover_nofsq(AceSynth *         ctx,
     s.instruction_str    = DIT_INSTR_COVER;
 
     if (!pinned_encode_src_and_timbre(ctx, src_audio, src_len, src_latents, src_T_latent, ref_audio, ref_len,
-                                      ref_latents, ref_T_latent, s)) {
+                                      ref_latents, ref_T_latent, s, progress)) {
         delete job;
         return NULL;
     }
-    if (run_tail(ctx, reqs, batch_n, s, cancel, cancel_data) != 0) {
+    if (run_tail(ctx, reqs, batch_n, s, progress) != 0) {
         delete job;
         return NULL;
     }
@@ -431,8 +429,7 @@ static AceSynthJob * run_repaint(AceSynth *         ctx,
                                  const float *      ref_latents,
                                  int                ref_T_latent,
                                  int                batch_n,
-                                 bool (*cancel)(void *),
-                                 void * cancel_data) {
+                                 AceProgress        progress) {
     bool have_audio   = src_audio && src_len > 0;
     bool have_latents = src_latents && src_T_latent > 0;
     if (!have_audio && !have_latents) {
@@ -453,7 +450,7 @@ static AceSynthJob * run_repaint(AceSynth *         ctx,
                               enc_latents, enc_T_latent);
 
     if (!pinned_encode_src_and_timbre(ctx, enc_audio, enc_len, enc_latents, enc_T_latent, ref_audio, ref_len,
-                                      ref_latents, ref_T_latent, s)) {
+                                      ref_latents, ref_T_latent, s, progress)) {
         delete job;
         return NULL;
     }
@@ -462,7 +459,7 @@ static AceSynthJob * run_repaint(AceSynth *         ctx,
         delete job;
         return NULL;
     }
-    if (run_tail(ctx, reqs, batch_n, s, cancel, cancel_data) != 0) {
+    if (run_tail(ctx, reqs, batch_n, s, progress) != 0) {
         delete job;
         return NULL;
     }
@@ -485,8 +482,7 @@ static AceSynthJob * run_lego(AceSynth *         ctx,
                               const float *      ref_latents,
                               int                ref_T_latent,
                               int                batch_n,
-                              bool (*cancel)(void *),
-                              void * cancel_data) {
+                              AceProgress        progress) {
     bool have_audio   = src_audio && src_len > 0;
     bool have_latents = src_latents && src_T_latent > 0;
     if (!have_audio && !have_latents) {
@@ -512,7 +508,7 @@ static AceSynthJob * run_lego(AceSynth *         ctx,
     }
 
     if (!pinned_encode_src_and_timbre(ctx, enc_audio, enc_len, enc_latents, enc_T_latent, ref_audio, ref_len,
-                                      ref_latents, ref_T_latent, s)) {
+                                      ref_latents, ref_T_latent, s, progress)) {
         delete job;
         return NULL;
     }
@@ -521,7 +517,7 @@ static AceSynthJob * run_lego(AceSynth *         ctx,
         delete job;
         return NULL;
     }
-    if (run_tail(ctx, reqs, batch_n, s, cancel, cancel_data) != 0) {
+    if (run_tail(ctx, reqs, batch_n, s, progress) != 0) {
         delete job;
         return NULL;
     }
@@ -540,8 +536,7 @@ static AceSynthJob * run_extract(AceSynth *         ctx,
                                  const float *      ref_latents,
                                  int                ref_T_latent,
                                  int                batch_n,
-                                 bool (*cancel)(void *),
-                                 void * cancel_data) {
+                                 AceProgress        progress) {
     bool have_src = (src_audio && src_len > 0) || (src_latents && src_T_latent > 0);
     if (!have_src) {
         fprintf(stderr, "[Synth-Run] ERROR: task 'extract' requires source audio or latents\n");
@@ -556,11 +551,11 @@ static AceSynthJob * run_extract(AceSynth *         ctx,
     warn_if_turbo_stem(ctx, "extract");
 
     if (!pinned_encode_src_and_timbre(ctx, src_audio, src_len, src_latents, src_T_latent, ref_audio, ref_len,
-                                      ref_latents, ref_T_latent, s)) {
+                                      ref_latents, ref_T_latent, s, progress)) {
         delete job;
         return NULL;
     }
-    if (run_tail(ctx, reqs, batch_n, s, cancel, cancel_data) != 0) {
+    if (run_tail(ctx, reqs, batch_n, s, progress) != 0) {
         delete job;
         return NULL;
     }
@@ -579,8 +574,7 @@ static AceSynthJob * run_complete(AceSynth *         ctx,
                                   const float *      ref_latents,
                                   int                ref_T_latent,
                                   int                batch_n,
-                                  bool (*cancel)(void *),
-                                  void * cancel_data) {
+                                  AceProgress        progress) {
     bool have_src = (src_audio && src_len > 0) || (src_latents && src_T_latent > 0);
     if (!have_src) {
         fprintf(stderr, "[Synth-Run] ERROR: task 'complete' requires source audio or latents\n");
@@ -595,11 +589,11 @@ static AceSynthJob * run_complete(AceSynth *         ctx,
     warn_if_turbo_stem(ctx, "complete");
 
     if (!pinned_encode_src_and_timbre(ctx, src_audio, src_len, src_latents, src_T_latent, ref_audio, ref_len,
-                                      ref_latents, ref_T_latent, s)) {
+                                      ref_latents, ref_T_latent, s, progress)) {
         delete job;
         return NULL;
     }
-    if (run_tail(ctx, reqs, batch_n, s, cancel, cancel_data) != 0) {
+    if (run_tail(ctx, reqs, batch_n, s, progress) != 0) {
         delete job;
         return NULL;
     }
@@ -620,38 +614,37 @@ AceSynthJob * ace_synth_job_run_dit(AceSynth *         ctx,
                                     const float *      ref_latents,
                                     int                ref_T_latent,
                                     int                batch_n,
-                                    bool (*cancel)(void *),
-                                    void * cancel_data) {
+                                    AceProgress        progress) {
     if (!ctx || !reqs || batch_n < 1 || batch_n > 9) {
         return NULL;
     }
     const std::string & task = reqs[0].task_type;
     if (task == TASK_TEXT2MUSIC) {
-        return run_text2music(ctx, reqs, ref_audio, ref_len, ref_latents, ref_T_latent, batch_n, cancel, cancel_data);
+        return run_text2music(ctx, reqs, ref_audio, ref_len, ref_latents, ref_T_latent, batch_n, progress);
     }
     if (task == TASK_COVER) {
         return run_cover(ctx, reqs, src_audio, src_len, src_latents, src_T_latent, ref_audio, ref_len, ref_latents,
-                         ref_T_latent, batch_n, cancel, cancel_data);
+                         ref_T_latent, batch_n, progress);
     }
     if (task == TASK_COVER_NOFSQ) {
         return run_cover_nofsq(ctx, reqs, src_audio, src_len, src_latents, src_T_latent, ref_audio, ref_len,
-                               ref_latents, ref_T_latent, batch_n, cancel, cancel_data);
+                               ref_latents, ref_T_latent, batch_n, progress);
     }
     if (task == TASK_REPAINT) {
         return run_repaint(ctx, reqs, src_audio, src_len, src_latents, src_T_latent, ref_audio, ref_len, ref_latents,
-                           ref_T_latent, batch_n, cancel, cancel_data);
+                           ref_T_latent, batch_n, progress);
     }
     if (task == TASK_LEGO) {
         return run_lego(ctx, reqs, src_audio, src_len, src_latents, src_T_latent, ref_audio, ref_len, ref_latents,
-                        ref_T_latent, batch_n, cancel, cancel_data);
+                        ref_T_latent, batch_n, progress);
     }
     if (task == TASK_EXTRACT) {
         return run_extract(ctx, reqs, src_audio, src_len, src_latents, src_T_latent, ref_audio, ref_len, ref_latents,
-                           ref_T_latent, batch_n, cancel, cancel_data);
+                           ref_T_latent, batch_n, progress);
     }
     if (task == TASK_COMPLETE) {
         return run_complete(ctx, reqs, src_audio, src_len, src_latents, src_T_latent, ref_audio, ref_len, ref_latents,
-                            ref_T_latent, batch_n, cancel, cancel_data);
+                            ref_T_latent, batch_n, progress);
     }
     fprintf(stderr, "[Synth-Run] ERROR: unknown task_type '%s'\n", task.c_str());
     return NULL;
@@ -666,15 +659,11 @@ const float * ace_synth_job_get_latent(const AceSynthJob * job, int track_idx, i
 }
 
 // Phase 2: latent splice (for repaint/lego) + VAE decode for every batch item.
-int ace_synth_job_run_vae(AceSynth *    ctx,
-                          AceSynthJob * job,
-                          AceAudio *    out,
-                          bool (*cancel)(void *),
-                          void * cancel_data) {
+int ace_synth_job_run_vae(AceSynth * ctx, AceSynthJob * job, AceAudio * out, AceProgress progress) {
     if (!ctx || !job || !out) {
         return -1;
     }
-    return ops_vae_decode(ctx, job->batch_n, out, job->state, cancel, cancel_data);
+    return ops_vae_decode(ctx, job->batch_n, out, job->state, progress);
 }
 
 void ace_synth_job_free(AceSynthJob * job) {

--- a/src/pipeline-synth.h
+++ b/src/pipeline-synth.h
@@ -8,6 +8,7 @@
 // caches everything across calls. DiT weight swap between phases is an
 // invisible consequence of the store, not an orchestration concern anymore.
 
+#include "progress.h"
 #include "request.h"
 
 #include <cstdlib>
@@ -60,7 +61,9 @@ AceSynth * ace_synth_load(ModelStore * store, const AceSynthParams * params);
 //   pass is skipped. Mutually exclusive per side: when both audio and latents
 //   are provided for the same side, latents win and audio is ignored.
 // batch_n: number of requests (1..9).
-// cancel/cancel_data: abort callback, polled between DiT steps. NULL = never cancel.
+// progress: abort + progress callback. Reports ACE_STAGE_DIT between DiT steps,
+// and ACE_STAGE_VAE_ENCODE while encoding the source and/or timbre reference in
+// Cover-family tasks. Default {} = never cancel, no progress.
 // Returns NULL on error or cancellation.
 AceSynthJob * ace_synth_job_run_dit(AceSynth *         ctx,
                                     const AceRequest * reqs,
@@ -73,8 +76,7 @@ AceSynthJob * ace_synth_job_run_dit(AceSynth *         ctx,
                                     const float *      ref_latents,
                                     int                ref_T_latent,
                                     int                batch_n,
-                                    bool (*cancel)(void *) = nullptr,
-                                    void * cancel_data     = nullptr);
+                                    AceProgress        progress = {});
 
 // Access the post-DiT denoised latent for one track of the job, owned by the
 // job and valid until ace_synth_job_free. Layout is flat [T_latent * 64] f32
@@ -88,11 +90,7 @@ const float * ace_synth_job_get_latent(const AceSynthJob * job, int track_idx, i
 // captured during phase 1, no source audio is needed.
 // out[batch_n] allocated by caller, filled with audio buffers.
 // Returns 0 on success, -1 on error or cancellation.
-int ace_synth_job_run_vae(AceSynth *    ctx,
-                          AceSynthJob * job,
-                          AceAudio *    out,
-                          bool (*cancel)(void *) = nullptr,
-                          void * cancel_data     = nullptr);
+int ace_synth_job_run_vae(AceSynth * ctx, AceSynthJob * job, AceAudio * out, AceProgress progress = {});
 
 void ace_synth_job_free(AceSynthJob * job);
 

--- a/src/pipeline-understand.cpp
+++ b/src/pipeline-understand.cpp
@@ -102,8 +102,7 @@ int ace_understand_generate(AceUnderstand *      ctx,
                             AceRequest *         out,
                             std::vector<float> * latent_out,
                             int *                T_latent_out,
-                            bool (*cancel)(void *),
-                            void * cancel_data) {
+                            AceProgress          progress) {
     if (!ctx || !req || !out) {
         return -1;
     }
@@ -161,10 +160,14 @@ int ace_understand_generate(AceUnderstand *      ctx,
         {
             ModelHandle vae_guard(ctx->store, vae_enc);
             T_25Hz = vae_enc_encode_tiled(vae_enc, src_audio, src_len, latents.data(), max_T_lat, ctx->params.vae_chunk,
-                                          ctx->params.vae_overlap);
+                                          ctx->params.vae_overlap, progress);
         }
         if (T_25Hz < 0) {
-            fprintf(stderr, "[Understand-VAE] FATAL: encode failed\n");
+            if (ace_cancelled(progress, ACE_STAGE_VAE_ENCODE)) {
+                fprintf(stderr, "[Understand-VAE] Cancelled\n");
+            } else {
+                fprintf(stderr, "[Understand-VAE] FATAL: encode failed\n");
+            }
             return -1;
         }
         fprintf(stderr, "[Understand-VAE] Encoded: %d latent frames (%.2fs), %.0fms\n", T_25Hz,
@@ -308,8 +311,13 @@ int ace_understand_generate(AceUnderstand *      ctx,
     bool             past_think = false;
     int              max_tokens = 4096;
 
+    if (ace_cancelled(progress,
+                      ACE_STAGE_LM)) {  // honour a cancel before the loop; the loop's step-0 poll sizes the bar
+        fprintf(stderr, "[Understand] Cancelled at step 0\n");
+        return -1;
+    }
     for (int step = 0; step < max_tokens; step++) {
-        if (cancel && cancel(cancel_data)) {
+        if (ace_progress(progress, ACE_STAGE_LM, step, max_tokens)) {
             fprintf(stderr, "[Understand] Cancelled at step %d\n", step);
             return -1;
         }

--- a/src/pipeline-understand.h
+++ b/src/pipeline-understand.h
@@ -5,6 +5,7 @@
 // the VAE encoder, FSQ tokenizer and LM from the store in sequence, with
 // RAII release between stages. Audio -> latents -> codes -> LM -> metadata.
 
+#include "progress.h"
 #include "request.h"
 
 #include <vector>
@@ -50,8 +51,9 @@ AceUnderstand * ace_understand_load(ModelStore * store, const AceUnderstandParam
 //   the capture. On the audio-in path, the buffer is filled (assigned)
 //   with [T_latent * 64] f32 and *T_latent_out is set; on any error path
 //   before tokenize, the buffer is left empty.
-// cancel/cancel_data: abort callback, polled between tokens. NULL = never cancel.
-// Returns 0 on success, -1 on error or cancellation.
+// progress: abort + progress callback. Reports ACE_STAGE_LM between tokens, and
+// ACE_STAGE_VAE_ENCODE while encoding input reference audio. Default {} = never
+// cancel, no progress. Returns 0 on success, -1 on error or cancellation.
 int ace_understand_generate(AceUnderstand *      ctx,
                             const float *        src_audio,
                             int                  src_len,
@@ -61,8 +63,7 @@ int ace_understand_generate(AceUnderstand *      ctx,
                             AceRequest *         out,
                             std::vector<float> * latent_out   = nullptr,
                             int *                T_latent_out = nullptr,
-                            bool (*cancel)(void *)            = nullptr,
-                            void * cancel_data                = nullptr);
+                            AceProgress          progress     = {});
 
 void ace_understand_free(AceUnderstand * ctx);
 

--- a/src/progress.h
+++ b/src/progress.h
@@ -1,0 +1,68 @@
+#pragma once
+// Progress + cancel callback for the generation pipelines.
+//
+// This widens the old `bool (*cancel)(void *)` + `void * cancel_data` pair (#18):
+// the same callback now reports where the run is (stage, step, total) AND cancels
+// by returning true. Every pipeline that took the cancel pair takes an
+// AceProgress by value instead, defaulted to {} (no callback = no progress, never
+// cancel), so callers that passed nothing are unchanged.
+
+enum AceStage {
+    ACE_STAGE_LM,          // LM planning + code generation
+    ACE_STAGE_DIT,         // DiT flow-matching sampler
+    ACE_STAGE_VAE_ENCODE,  // VAE tiled encode (reference audio -> latents)
+    ACE_STAGE_VAE_DECODE,  // VAE tiled decode (latents -> audio)
+    ACE_STAGE_MP3,         // MP3 output encode
+};
+
+// fn is called at each pipeline poll with the current (stage, step, total) and
+// returns true to cancel the run. step is 0-based; total is the loop's iteration
+// count. The loop's first iteration (step 0) reports before the first unit of
+// work, so a UI can size a segmented bar. fn == nullptr means no progress and
+// never cancel.
+//
+// total is an upper bound, not a promise: an LM stage reports total =
+// max_new_tokens / max_tokens but stops early once every sequence hits EOS
+// (usually far below total), so an LM bar should treat it as a ceiling and expect
+// the stage to end before reaching it.
+//
+// A call with step < 0 is a bare cancel poll (see ace_cancelled), NOT a progress
+// report: a progress-recording callback should honour its cancel return but skip
+// it for sizing/advancing. It is used before a loop (to honour a cancel that
+// landed before step 0 -- an empty loop therefore emits no step-0 report, only
+// this poll), where there is no meaningful iteration index (MP3 encode), and in
+// the VAE error-vs-cancel disambiguation -- so those never inject bogus steps
+// into a stage's stream.
+//
+// Cancel must be level-triggered: once the run is cancelled, fn must keep
+// returning true (the server reads a std::atomic<bool> flag, which is). The
+// disambiguation re-polls rely on that.
+//
+// A stage may run more than once in a single request, each run re-emitting its
+// step-0 sizing report followed by 0..N -- so a consumer should treat step 0 as
+// the start of a (repeatable) pass, not assume a stage appears once. VAE encode
+// runs for the source and the timbre reference in Cover tasks; VAE decode runs
+// once per batch item; and DiT and LM repeat once per group in batched synthesis.
+//
+// Thread-safety: fn is always called from a single thread. The pipelines poll it
+// sequentially, and MP3 encode -- though fork-join -- polls cancel only from its
+// single-threaded post-join point, never from a worker. So fn need not be
+// thread-safe.
+struct AceProgress {
+    bool (*fn)(void * data, AceStage stage, int step, int total) = nullptr;
+    void * data                                                  = nullptr;
+};
+
+// The single place the pipelines poll for progress: reports (stage, step, total)
+// and returns true if the callback asked to cancel.
+static inline bool ace_progress(const AceProgress & p, AceStage stage, int step, int total) {
+    return p.fn && p.fn(p.data, stage, step, total);
+}
+
+// A cancel poll with nothing to report -- for sites with no iteration index (MP3
+// encode) or that re-check cancel after a failing return (VAE encode/decode) to
+// tell a cancel from an error. Passes step/total = -1 so a progress consumer can
+// tell it from a real report; returns true if cancelled.
+static inline bool ace_cancelled(const AceProgress & p, AceStage stage) {
+    return p.fn && p.fn(p.data, stage, -1, -1);
+}

--- a/src/vae-enc.h
+++ b/src/vae-enc.h
@@ -6,6 +6,7 @@
 // Downsample: 2x4x4x6x10 = 1920x (matches decoder upsample)
 
 #pragma once
+#include "progress.h"
 #include "vae.h"
 
 // Encoder block: 3xResUnit(in_ch) -> snake(in_ch) -> strided Conv1d(in_ch -> out_ch)
@@ -295,7 +296,8 @@ static int vae_enc_encode_tiled(VAEEncoder *  m,
                                 float *       latent_out,  // [T_latent, 64] output, time-major
                                 int           max_T_latent,
                                 int           chunk_size = 256,
-                                int           overlap    = 64) {
+                                int           overlap    = 64,
+                                AceProgress   progress   = {}) {
     // Work in audio-sample space. Each latent frame = 1920 audio samples.
     int audio_chunk   = chunk_size * 1920;
     int audio_overlap = overlap * 1920;
@@ -305,8 +307,14 @@ static int vae_enc_encode_tiled(VAEEncoder *  m,
         audio_overlap /= 2;
     }
 
-    // Short audio: encode directly
+    // Short audio: encode directly, as one implicit tile. Still report it and
+    // honour a cancel, so a short input is neither invisible to a progress bar
+    // nor uncancellable (the encode itself is a single un-interruptible graph).
     if (T_audio <= audio_chunk) {
+        if (ace_progress(progress, ACE_STAGE_VAE_ENCODE, 0, 1)) {
+            fprintf(stderr, "[VAE-Enc] Cancelled at tile 0/1\n");
+            return -1;
+        }
         return vae_enc_encode(m, audio, T_audio, latent_out, max_T_latent);
     }
 
@@ -319,7 +327,16 @@ static int vae_enc_encode_tiled(VAEEncoder *  m,
     float downsample_factor = 0.0f;
     int   latent_write_pos  = 0;
 
+    if (ace_cancelled(progress,
+                      ACE_STAGE_VAE_ENCODE)) {  // honour a cancel before the loop; the loop's step-0 poll sizes the bar
+        fprintf(stderr, "[VAE-Enc] Cancelled at tile 0/%d\n", num_steps);
+        return -1;
+    }
     for (int i = 0; i < num_steps; i++) {
+        if (ace_progress(progress, ACE_STAGE_VAE_ENCODE, i, num_steps)) {
+            fprintf(stderr, "[VAE-Enc] Cancelled at tile %d/%d\n", i, num_steps);
+            return -1;
+        }
         // Core range in audio samples (the part we keep)
         int core_start = i * audio_stride;
         int core_end   = core_start + audio_stride;

--- a/src/vae.h
+++ b/src/vae.h
@@ -12,6 +12,7 @@
 #include "ggml-backend.h"
 #include "ggml.h"
 #include "gguf-weights.h"
+#include "progress.h"
 
 #include <cmath>
 #include <cstdio>
@@ -371,9 +372,9 @@ static struct ggml_tensor * vae_ggml_build_graph(struct ggml_context * ctx,
 // Core compute: ensure graph cached, set input, run. Returns T_audio or -1.
 // Output remains in m->graph_output for caller to read as needed.
 static int vae_ggml_compute(VAEGGML *     m,
-                            const float * latent,    // [T_full, 64] time-major
-                            int           T_latent,  // window length to decode
-                            int           win_start = 0) {     // offset into latent
+                            const float * latent,           // [T_full, 64] time-major
+                            int           T_latent,         // window length to decode
+                            int           win_start = 0) {  // offset into latent
 
     // Build graph only when T_latent changes (cached for tiled decode reuse)
     if (m->graph_T != T_latent) {
@@ -471,15 +472,20 @@ static int vae_ggml_decode_tiled(VAEGGML *     m,
                                  int           max_T_audio,
                                  int           chunk_size = 256,
                                  int           overlap    = 64,
-                                 bool (*cancel)(void *)   = nullptr,
-                                 void * cancel_data       = nullptr) {
+                                 AceProgress   progress   = {}) {
     // Ensure positive stride (matches Python effective_overlap reduction)
     while (chunk_size - 2 * overlap <= 0 && overlap > 0) {
         overlap /= 2;
     }
 
-    // Short sequence: decode directly
+    // Short sequence: decode directly, as one implicit tile. Still report it and
+    // honour a cancel, so a short input is neither invisible to a progress bar
+    // nor uncancellable (the decode itself is a single un-interruptible graph).
     if (T_latent <= chunk_size) {
+        if (ace_progress(progress, ACE_STAGE_VAE_DECODE, 0, 1)) {
+            fprintf(stderr, "[VAE] Cancelled at tile 0/1\n");
+            return -1;
+        }
         return vae_ggml_decode(m, latent, T_latent, audio_out, max_T_audio);
     }
 
@@ -492,8 +498,13 @@ static int vae_ggml_decode_tiled(VAEGGML *     m,
     float upsample_factor = 0.0f;
     int   audio_write_pos = 0;
 
+    if (ace_cancelled(progress,
+                      ACE_STAGE_VAE_DECODE)) {  // honour a cancel before the loop; the loop's step-0 poll sizes the bar
+        fprintf(stderr, "[VAE] Cancelled at tile 0/%d\n", num_steps);
+        return -1;
+    }
     for (int i = 0; i < num_steps; i++) {
-        if (cancel && cancel(cancel_data)) {
+        if (ace_progress(progress, ACE_STAGE_VAE_DECODE, i, num_steps)) {
             fprintf(stderr, "[VAE] Cancelled at tile %d/%d\n", i, num_steps);
             return -1;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+# test-progress: the AceProgress report/cancel contract (#18). Header-only.
+add_executable(test-progress test-progress.cpp)
+target_include_directories(test-progress PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
 # test-philox: Philox RNG reference dumper.
 add_executable(test-philox test-philox.cpp)
 target_include_directories(test-philox PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/tests/test-progress.cpp
+++ b/tests/test-progress.cpp
@@ -1,0 +1,142 @@
+// test-progress: the AceProgress report/cancel contract (#18).
+//
+// Header-only -- exercises ace_progress() and the pre-loop + per-step reporting
+// pattern the pipelines use, without loading any model. It checks that a run
+// emits ordered (stage, step, total) reports for each stage, that step 0 is
+// reported before the first unit of work, and that returning true cancels.
+#include "progress.h"
+
+#include <cstdio>
+#include <vector>
+
+static int failures = 0;
+
+#define CHECK(cond)                                                         \
+    do {                                                                    \
+        if (!(cond)) {                                                      \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+            failures++;                                                     \
+        }                                                                   \
+    } while (0)
+
+struct Report {
+    AceStage stage;
+    int      step;
+    int      total;
+};
+
+// Records every call; cancels when the level-triggered flag is set or when step
+// reaches cancel_at (-1 = never).
+struct Recorder {
+    std::vector<Report> reports;
+    int                 cancel_at = -1;
+    bool                flag      = false;
+};
+
+static bool record_fn(void * data, AceStage stage, int step, int total) {
+    auto * r = static_cast<Recorder *>(data);
+    r->reports.push_back({ stage, step, total });
+    return r->flag || (r->cancel_at >= 0 && step >= r->cancel_at);
+}
+
+// Mirrors what every pipeline loop does: a bare cancel poll before the loop (so
+// an already-cancelled stage aborts even when total == 0), then poll+report at
+// the top of each iteration -- iteration 0 (step 0) sizes the bar. Returns the
+// step it cancelled at, or total if it ran fully.
+static int run_stage(const AceProgress & p, AceStage stage, int total) {
+    if (ace_cancelled(p, stage)) {  // no progress report; honours a cancel before the loop
+        return -1;
+    }
+    for (int step = 0; step < total; step++) {
+        if (ace_progress(p, stage, step, total)) {
+            return step;  // cancelled
+        }
+        // ... work ...
+    }
+    return total;
+}
+
+int main() {
+    // 1. A default (empty) AceProgress never cancels and never calls anything.
+    {
+        AceProgress none;
+        CHECK(!ace_progress(none, ACE_STAGE_DIT, 3, 10));
+        CHECK(run_stage(none, ACE_STAGE_DIT, 5) == 5);  // ran fully, no callback
+    }
+
+    // 2. A run reports ordered (stage, step, total) covering all four stages, with
+    //    step 0 emitted before the first unit of work.
+    {
+        Recorder    rec;
+        AceProgress p{ record_fn, &rec };
+
+        const struct {
+            AceStage stage;
+            int      total;
+        } stages[] = {
+            { ACE_STAGE_LM,         4 },
+            { ACE_STAGE_DIT,        3 },
+            { ACE_STAGE_VAE_ENCODE, 2 },
+            { ACE_STAGE_VAE_DECODE, 3 },
+        };
+
+        for (auto & s : stages) {
+            CHECK(run_stage(p, s.stage, s.total) == s.total);
+        }
+
+        // The progress reports (step >= 0; the bare cancel polls at step -1 are
+        // not progress) are, per stage, exactly 0..total-1: step 0 first (the
+        // sizing report, before any work), then non-decreasing, total constant.
+        std::vector<Report> prog;
+        for (auto & r : rec.reports) {
+            if (r.step >= 0) {
+                prog.push_back(r);
+            }
+        }
+        size_t i = 0;
+        for (auto & s : stages) {
+            for (int step = 0; step < s.total; step++, i++) {
+                CHECK(i < prog.size());
+                CHECK(prog[i].stage == s.stage);
+                CHECK(prog[i].step == step);
+                CHECK(prog[i].total == s.total);
+            }
+        }
+        CHECK(i == prog.size());  // no extra progress reports
+    }
+
+    // 3. Returning true cancels at that step, and the loop stops there.
+    {
+        Recorder rec;
+        rec.cancel_at = 2;
+        AceProgress p{ record_fn, &rec };
+        CHECK(run_stage(p, ACE_STAGE_DIT, 10) == 2);  // stopped at step 2, not 10
+        // sizing(0) + poll(0),poll(1),poll(2)=cancel -> last recorded step is 2.
+        CHECK(!rec.reports.empty());
+        CHECK(rec.reports.back().step == 2);
+    }
+
+    // 4. ace_cancelled is a bare cancel poll: it honours the cancel return but
+    //    marks itself with step < 0 so a consumer can skip it for progress.
+    {
+        Recorder    rec;
+        AceProgress p{ record_fn, &rec };
+        CHECK(!ace_cancelled(p, ACE_STAGE_MP3));  // not cancelled
+        CHECK(rec.reports.size() == 1);
+        CHECK(rec.reports.back().stage == ACE_STAGE_MP3);
+        CHECK(rec.reports.back().step < 0);  // distinguishable from a real report
+
+        rec.flag = true;                     // now the (level-triggered) callback cancels
+        CHECK(ace_cancelled(p, ACE_STAGE_MP3));
+
+        AceProgress none;
+        CHECK(!ace_cancelled(none, ACE_STAGE_MP3));  // null fn: never cancels
+    }
+
+    if (failures == 0) {
+        printf("test-progress: all checks passed\n");
+        return 0;
+    }
+    fprintf(stderr, "test-progress: %d check(s) failed\n", failures);
+    return 1;
+}

--- a/tools/ace-lm.cpp
+++ b/tools/ace-lm.cpp
@@ -159,7 +159,7 @@ int main(int argc, char ** argv) {
         reqs[b].seed    = req.seed + b;
     }
     std::vector<AceRequest> out(lm_batch_size);
-    if (ace_lm_generate(ctx, reqs.data(), lm_batch_size, out.data(), dump_logits, dump_tokens, NULL, NULL, mode) != 0) {
+    if (ace_lm_generate(ctx, reqs.data(), lm_batch_size, out.data(), dump_logits, dump_tokens, AceProgress{}, mode) != 0) {
         ace_lm_free(ctx);
         store_free(store);
         return 1;

--- a/tools/ace-server.cpp
+++ b/tools/ace-server.cpp
@@ -511,8 +511,11 @@ static void handle_logs(const httplib::Request &, httplib::Response & res) {
         });
 }
 
-// cancel callback: checks the per-job cancel flag.
-static bool server_cancel_job(void * data) {
+// progress + cancel callback. Reports (stage, step, total) are ignored here --
+// the client polls job status separately -- but the return still cancels via the
+// per-job flag. It only reads the atomic, so it has no thread-safety needs of
+// its own (the pipelines call it from a single thread regardless).
+static bool server_progress(void * data, AceStage /*stage*/, int /*step*/, int /*total*/) {
     auto * flag = (const std::atomic<bool> *) data;
     return flag && flag->load(std::memory_order_relaxed);
 }
@@ -579,8 +582,8 @@ static void lm_worker(std::shared_ptr<Job> job, std::vector<AceRequest> ace_reqs
     // Execute and always free the ctx, success or failure: the store decides
     // whether the underlying GPU module stays resident.
     std::vector<AceRequest> out(N);
-    int rc = ace_lm_generate(ctx, ace_reqs.data(), N, out.data(), NULL, NULL, server_cancel_job, (void *) &job->cancel,
-                             mode);
+    int rc = ace_lm_generate(ctx, ace_reqs.data(), N, out.data(), NULL, NULL,
+                             AceProgress{ server_progress, (void *) &job->cancel }, mode);
     ace_lm_free(ctx);
 
     if (rc != 0) {
@@ -834,7 +837,7 @@ static void synth_worker(std::shared_ptr<Job>    job,
     std::vector<std::vector<float>> captured_latents;
     const int rc = synth_batch_run(ctx, groups, src_interleaved, src_len, src_lat_ptr, src_T_latent, ref_interleaved,
                                    ref_len, ref_lat_ptr, ref_T_latent, audio.data(), &captured_latents,
-                                   server_cancel_job, (void *) &job->cancel);
+                                   AceProgress{ server_progress, (void *) &job->cancel });
     ace_synth_free(ctx);
     free(src_interleaved);
     free(ref_interleaved);
@@ -878,7 +881,7 @@ static void synth_worker(std::shared_ptr<Job>    job,
             encoded[b] = audio_encode_wav(audio[b].samples, audio[b].n_samples, 48000, wav_fmt);
         } else {
             encoded[b] = audio_encode_mp3(audio[b].samples, audio[b].n_samples, 48000, groups[0][b].mp3_bitrate,
-                                          server_cancel_job, (void *) &job->cancel);
+                                          AceProgress{ server_progress, (void *) &job->cancel });
         }
         ace_audio_free(&audio[b]);
     }
@@ -1113,7 +1116,8 @@ static void understand_worker(std::shared_ptr<Job> job,
     int                captured_T_latent = 0;
     const float *      src_lat_ptr       = src_latents.empty() ? nullptr : src_latents.data();
     int rc = ace_understand_generate(ctx, src_interleaved, src_len, src_lat_ptr, src_T_latent, &ace_req, &out,
-                                     &captured_latent, &captured_T_latent, server_cancel_job, (void *) &job->cancel);
+                                     &captured_latent, &captured_T_latent,
+                                     AceProgress{ server_progress, (void *) &job->cancel });
     ace_understand_free(ctx);
     free(src_interleaved);
 
@@ -1280,10 +1284,12 @@ static void decode_worker(std::shared_ptr<Job> job,
     int                T_audio_max = (src_T_latent + 64) * 1920;
     std::vector<float> audio_buf((size_t) T_audio_max * 2);
     int T_audio = vae_ggml_decode_tiled(vae, src_latents.data(), src_T_latent, audio_buf.data(), T_audio_max,
-                                        g_synth_params.vae_chunk, g_synth_params.vae_overlap);
+                                        g_synth_params.vae_chunk, g_synth_params.vae_overlap,
+                                        AceProgress{ server_progress, (void *) &job->cancel });
     if (T_audio < 0) {
-        fprintf(stderr, "[Server] decode: vae_ggml_decode_tiled failed\n");
-        job->status.store(JobStatus::FAILED);
+        bool cancelled = job->cancel.load();
+        fprintf(stderr, "[Server] decode: %s\n", cancelled ? "cancelled" : "vae_ggml_decode_tiled failed");
+        job->status.store(cancelled ? JobStatus::CANCELLED : JobStatus::FAILED);
         return;
     }
     fprintf(stderr, "[Server] decode: %d latent frames -> %d audio samples (%.2fs), %.0fms\n", src_T_latent, T_audio,
@@ -1306,8 +1312,8 @@ static void decode_worker(std::shared_ptr<Job> job,
     if (output_wav) {
         encoded = audio_encode_wav(audio_buf.data(), T_audio, 48000, wav_fmt);
     } else {
-        encoded = audio_encode_mp3(audio_buf.data(), T_audio, 48000, ace_req.mp3_bitrate, server_cancel_job,
-                                   (void *) &job->cancel);
+        encoded = audio_encode_mp3(audio_buf.data(), T_audio, 48000, ace_req.mp3_bitrate,
+                                   AceProgress{ server_progress, (void *) &job->cancel });
     }
 
     // Response: raw audio, single Content-Type. No latent in the body: the
@@ -1369,11 +1375,13 @@ static void encode_worker(std::shared_ptr<Job> job, AceRequest ace_req, float * 
         T_latent_max = MAX_T_LATENT;
     }
     std::vector<float> latent((size_t) T_latent_max * LATENT_CHANNELS);
-    int                T_latent = vae_enc_encode_tiled(vae, src_interleaved, src_len, latent.data(), T_latent_max,
-                                                       g_synth_params.vae_chunk, g_synth_params.vae_overlap);
+    int                T_latent =
+        vae_enc_encode_tiled(vae, src_interleaved, src_len, latent.data(), T_latent_max, g_synth_params.vae_chunk,
+                             g_synth_params.vae_overlap, AceProgress{ server_progress, (void *) &job->cancel });
     if (T_latent < 0) {
-        fprintf(stderr, "[Server] encode: vae_enc_encode_tiled failed\n");
-        job->status.store(JobStatus::FAILED);
+        bool cancelled = job->cancel.load();
+        fprintf(stderr, "[Server] encode: %s\n", cancelled ? "cancelled" : "vae_enc_encode_tiled failed");
+        job->status.store(cancelled ? JobStatus::CANCELLED : JobStatus::FAILED);
         return;
     }
     fprintf(stderr, "[Server] encode: %d audio samples (%.2fs) -> %d latent frames, %.0fms\n", src_len,

--- a/tools/ace-understand.cpp
+++ b/tools/ace-understand.cpp
@@ -189,8 +189,7 @@ int main(int argc, char ** argv) {
     // same entry point with the full latent IO surface.
     request_resolve_lm_seed(&req);
     AceRequest out;
-    int rc = ace_understand_generate(ctx, src_interleaved, src_len, nullptr, 0, &req, &out, nullptr, nullptr, nullptr,
-                                     nullptr);
+    int rc = ace_understand_generate(ctx, src_interleaved, src_len, nullptr, 0, &req, &out, nullptr, nullptr, {});
     free(src_interleaved);
     ace_understand_free(ctx);
     store_free(store);

--- a/tools/synth-batch-runner.h
+++ b/tools/synth-batch-runner.h
@@ -43,8 +43,7 @@ static int synth_batch_run(AceSynth *                             ctx,
                            int                                    ref_T_latent,
                            AceAudio *                             audio_out,
                            std::vector<std::vector<float>> *      latents_out = nullptr,
-                           bool (*cancel)(void *)                             = nullptr,
-                           void * cancel_data                                 = nullptr) {
+                           AceProgress                            progress    = {}) {
     const int                  n_groups = (int) groups.size();
     std::vector<AceSynthJob *> jobs(n_groups, nullptr);
     std::vector<int>           audio_off(n_groups, 0);
@@ -59,7 +58,7 @@ static int synth_batch_run(AceSynth *                             ctx,
     for (int g = 0; g < n_groups; g++) {
         const int gn = (int) groups[g].size();
         jobs[g] = ace_synth_job_run_dit(ctx, groups[g].data(), src_audio, src_len, src_latents, src_T_latent, ref_audio,
-                                        ref_len, ref_latents, ref_T_latent, gn, cancel, cancel_data);
+                                        ref_len, ref_latents, ref_T_latent, gn, progress);
         if (!jobs[g]) {
             for (int j = 0; j < g; j++) {
                 ace_synth_job_free(jobs[j]);
@@ -88,7 +87,7 @@ static int synth_batch_run(AceSynth *                             ctx,
     // Phase 2: latent splice + VAE decode for each job. The decoder is
     // acquired and released by ops_vae_decode inside ace_synth_job_run_vae.
     for (int g = 0; g < n_groups; g++) {
-        const int rc = ace_synth_job_run_vae(ctx, jobs[g], audio_out + audio_off[g], cancel, cancel_data);
+        const int rc = ace_synth_job_run_vae(ctx, jobs[g], audio_out + audio_off[g], progress);
         ace_synth_job_free(jobs[g]);
         jobs[g] = nullptr;
         if (rc != 0) {


### PR DESCRIPTION
Third of four small embedder patches from [Cadenza](https://github.com/erichchampion/cadenza-audio) (independent of the others; ported onto current master's heterogeneous LM batching from #9761469 and the dropped DiT padding-mask plumbing from #da5bc90).

## What it does

The pipelines took `bool (*cancel)(void *)` + `void * cancel_data`. The same callback now also reports where the run is:

```cpp
struct AceProgress {
    bool (*fn)(void * data, AceStage stage, int step, int total) = nullptr;
    void * data                                                  = nullptr;
};
```

Every pipeline poll calls `fn` with the current stage and loop position, and returning true still cancels -- so a UI gets a real progress bar over the exact hook it already had to implement anyway. The HTTP server's `/progress` poll-with-cancel is the visible beneficiary: today a client can cancel but cannot know whether the run is in LM, DiT or VAE, or how far along.

- **Passed by value, defaulted to `{}`** (no callback = no progress and never cancel), so every existing caller that passed nothing is unchanged, and callers that passed a cancel pair keep identical cancellation semantics.
- **Stages**: LM, DiT, VAE encode, VAE decode, MP3. `step` is 0-based, and a step-0 report fires before a loop's first unit of work, so a segmented bar can be sized even for empty loops.
- **Thread-safety is documented**: fn is called sequentially for LM, DiT and VAE, but MP3 encode is fork-join, so fn may be called concurrently there -- safe for the flag-reading implementations that are the common case.

## Testing

`tests/test-progress.cpp` exercises the report/cancel contract: report sequence, cancel mid-loop, and the step-0-before-first-work guarantee. Built and run on macOS/arm64/Metal.