### PR TITLE
core: explicit CPU thread count and compute-device selection for embedders

### DIFF
--- a/src/audio-io.h
+++ b/src/audio-io.h
@@ -5,6 +5,7 @@
 // All functions use planar stereo float: [L: T samples][R: T samples].
 // Part of acestep.cpp. MIT license.
 
+#include "backend-config.h"
 #include "task-types.h"
 
 #include <algorithm>
@@ -608,13 +609,19 @@ static std::string audio_encode_mp3(const float * audio,
     float duration = (float) enc_T / (float) enc_sr;
     fprintf(stderr, "[MP3] Encoding %.1fs @ %d kbps, %d Hz stereo\n", duration, kbps, enc_sr);
 
-    // thread count: all logical cores. MP3 is ALU-bound with small working set,
-    // hyperthreads help (unlike GGML GEMM which shares SIMD units).
-    // minimum ~2s per chunk so filter warmup at boundaries is negligible.
-    int n_threads = (int) std::thread::hardware_concurrency();
-    if (n_threads < 1) {
-        n_threads = 1;
-    }
+    // thread count: an explicit ace_backend_configure() cap wins -- an embedder
+    // bounding CPU for battery/thermals means the MP3 export too, not just
+    // inference. With no cap, all logical cores: MP3 is ALU-bound with a small
+    // working set, so hyperthreads help here (unlike GGML GEMM, which shares SIMD
+    // units, hence the P-core default in backend.h -- so both the auto default and
+    // the clamp ceiling here are the logical count, not that P-core count). Same
+    // shared clamp as backend_cpu_n_threads(), sourced from the same ace_logical_cpus()
+    // (robust to hardware_concurrency() returning 0 via an Apple sysctl), so an
+    // absurd cap can't spawn that many encoders and auto never collapses to 1; the
+    // length-based max_threads below is a second ceiling regardless. minimum ~2s per
+    // chunk so filter warmup at boundaries is negligible.
+    int logical      = ace_logical_cpus();
+    int n_threads    = ace_resolve_threads(ace_backend_config().n_threads, logical, logical);
     int total_frames = (enc_T + 1151) / 1152;
     int min_frames   = (enc_sr * 2 + 1151) / 1152;  // ~2s worth of frames
     int max_threads  = total_frames / (min_frames > 0 ? min_frames : 1);

--- a/src/backend-config.h
+++ b/src/backend-config.h
@@ -1,0 +1,114 @@
+#pragma once
+// Explicit CPU thread count and compute-device selection for embedders (#19).
+//
+// An app calls ace_backend_configure() once, before its first model load, instead
+// of relying on the GGML_BACKEND environment variable -- an app does not configure
+// itself with getenv. The env var stays as a fallback for the CLIs: when nothing
+// has been configured, backend init still honours GGML_BACKEND, then auto-picks
+// the best device.
+//
+// All the setters below are setup-time only and unsynchronized: the engine reads
+// this config (holding a reference to the device string) at the first model load,
+// so set it before any generate/load call and never from another thread while one
+// is running. It is set-once configuration, not a live control surface.
+//
+// This header is deliberately free of any ggml dependency so an embedder can
+// include just it to configure the engine; backend.h reads the config. Like the
+// rest of the engine's API it is C++ (not extern "C"): a Swift/Obj-C app calls it
+// from its C++ or Objective-C++ bridge (the same shim it already needs for
+// ace_synth_* etc.), not from Swift directly.
+#include <string>
+#include <thread>
+
+#ifdef __APPLE__
+#    include <sys/sysctl.h>
+#endif
+
+struct AceBackendConfig {
+    std::string device;         // backend name (e.g. "Metal", "CUDA0", "CPU"); "" = auto
+    int         n_threads = 0;  // CPU worker threads; <= 0 = auto
+};
+
+// The one config instance, shared across translation units that link into the
+// same image: a function-local static inside an inline (external-linkage) function
+// has one instance per linked image, so the app's ace_backend_configure() and the
+// engine's backend init read the same object even in different TUs. acestep-core
+// links statically (build-ios-libs.sh, the CMake STATIC lib), so that image is the
+// whole app -- one instance. If the engine were ever built as a separate
+// dylib/framework, this static could duplicate across the boundary; move it to a
+// .cpp (one external definition) then.
+inline AceBackendConfig & ace_backend_config() {
+    static AceBackendConfig cfg;
+    return cfg;
+}
+
+// Set the compute device: backend name, or NULL/"" for auto (falls back to the
+// GGML_BACKEND env var, then the best available device).
+inline void ace_backend_set_device(const char * device) {
+    ace_backend_config().device = device ? device : "";
+}
+
+// Set the CPU worker thread count. This one value governs both workloads: the GGML
+// inference threads and the MP3 export encoder threads. A positive count caps both
+// (an embedder bounding CPU for battery/thermals means the whole pipeline). <= 0
+// means auto, and the auto default differs by workload because their optimal thread
+// policies differ: GGML uses the performance-core count on Apple silicon
+// (hardware_concurrency()/2 elsewhere) since GEMM shares SIMD units across
+// hyperthreads, while MP3 -- ALU-bound with a small working set -- uses all logical
+// cores. There is deliberately one knob, not one per workload.
+inline void ace_backend_set_threads(int n_threads) {
+    ace_backend_config().n_threads = n_threads;
+}
+
+// Set BOTH device and thread count at once -- a convenience for the common
+// configure-once-at-startup call. It sets the full config, so passing e.g.
+// (nullptr, 8) also resets the device to auto; to change only one field later use
+// the single-field setters above. Not thread-safe: call during setup, before any
+// generate call.
+inline void ace_backend_configure(const char * device, int n_threads) {
+    ace_backend_set_device(device);
+    ace_backend_set_threads(n_threads);
+}
+
+// The logical CPU count: std::thread::hardware_concurrency(), with an Apple sysctl
+// fallback (hw.logicalcpu) for the rare case it returns 0, so a caller that uses the
+// logical count as an auto default or a clamp ceiling gets a real number instead of
+// collapsing to 1. Always >= 1. Shared (ggml-free) so backend.h and audio-io.h both
+// source their logical-CPU reference here rather than each calling the raw query.
+inline int ace_logical_cpus() {
+    int n = (int) std::thread::hardware_concurrency();
+    if (n > 0) {
+        return n;
+    }
+#ifdef __APPLE__
+    int    logical = 0;
+    size_t sz      = sizeof(logical);
+    if (sysctlbyname("hw.logicalcpu", &logical, &sz, nullptr, 0) == 0 && logical > 0) {
+        return logical;
+    }
+#endif
+    return 1;
+}
+
+// Resolve a CPU worker-thread count from an embedder's configured value. One
+// definition, shared by the GGML backend (backend.h) and the MP3 encoder
+// (audio-io.h), so the clamp rule stays in one place and cannot drift between them.
+//   configured <= 0 -> auto: return auto_threads (each caller's own default policy)
+//   configured  > 0 -> honour it, clamped to a ceiling so a bogus value (100000)
+//                      cannot spawn that many threads. The ceiling is the logical
+//                      CPU count when known (hw), else auto_threads -- so the clamp
+//                      still bites when hardware_concurrency() reports 0.
+// auto_threads is the caller's own auto default (the P-core count for GGML GEMM, all
+// logical cores for the ALU-bound MP3 path); it is forced to >= 1, so the result is
+// always >= 1. Pure arithmetic -- no ggml, no platform detection -- so it belongs
+// with the rest of this ggml-free config header.
+inline int ace_resolve_threads(int configured, int hw, int auto_threads) {
+    if (auto_threads < 1) {
+        auto_threads = 1;
+    }
+    if (configured <= 0) {
+        return auto_threads;
+    }
+    const int ceiling = hw > 0 ? hw : auto_threads;
+    return configured > ceiling ? ceiling : configured;
+}

--- a/src/backend.h
+++ b/src/backend.h
@@ -5,6 +5,7 @@
 // keep CPU as fallback. This avoids duplicating init logic across
 // qwen3.h, qwen3-lm.h, cond.h, dit.h, vae.h.
 
+#include "backend-config.h"
 #include "ggml-backend.h"
 
 #include <cstdio>
@@ -12,22 +13,64 @@
 #include <cstring>
 #include <thread>
 
+#ifdef __APPLE__
+#    include <sys/sysctl.h>
+#endif
+
 struct BackendPair {
     ggml_backend_t backend;
     ggml_backend_t cpu_backend;
     bool           has_gpu;
 };
 
-// Cached backend state (shared across all modules in the same binary)
+// Cached backend state, shared across every model that loads within one binary.
+// static-in-header (internal linkage) means one copy per TU, not one program-wide
+// like ace_backend_config() -- and that is fine only because exactly one TU per
+// binary ever reaches backend_init(): in the engine every load goes through
+// model-store.cpp's store_require_*, and the neural-codec tool is a standalone TU
+// that loads its own VAE. If a second TU in the same binary ever called a loader
+// directly, its loads would get a separate cache and refcount and not share --
+// make this a shared singleton (ace_backend_config-style) if that day comes.
 static BackendPair g_backend_cache = {};
 static int         g_backend_refs  = 0;
 
-// Physical core count heuristic (logical / 2 for HT/SMT).
-// Used for GGML CPU thread count: GEMM shares SIMD units across hyperthreads,
-// so one thread per physical core is optimal.
-static int backend_cpu_n_threads(void) {
+// The auto GGML CPU thread count: one thread per useful physical core. GEMM
+// shares SIMD units across hyperthreads, so one-per-physical is optimal.
+static int backend_cpu_auto_threads(void) {
+#ifdef __APPLE__
+    // Apple silicon has no SMT and asymmetric cores, so logical/2 is the wrong
+    // count -- it halves as if for hyperthreads. hw.perflevel0 is the
+    // performance-core cluster, the cores GEMM should run on: the E-cores are
+    // much slower and just drag a shared graph. That is 12 P-cores on an M3 Max
+    // (12P+4E, where logical/2 gave 8) and 2 on an iPhone 15 Pro (2P+4E, where
+    // logical/2 gave 3) -- fewer than before on a 2P device, but the fast cores
+    // only, which is the one-thread-per-useful-physical-core this function wants.
+    // (physicalcpu == logicalcpu here anyway, no SMT; physicalcpu just reads as
+    // the honest intent.) The perflevel sysctls exist only on Apple silicon: on an
+    // Intel Mac this query fails and control falls through to the logical/2 below,
+    // which is the right answer there because Intel does have SMT.
+    int    perf = 0;
+    size_t sz   = sizeof(perf);
+    if (sysctlbyname("hw.perflevel0.physicalcpu", &perf, &sz, nullptr, 0) == 0 && perf > 0) {
+        return perf;
+    }
+#endif
+    // Non-Apple: x86 with SMT is the target, where logical / 2 approximates the
+    // physical core count. (A non-SMT non-Apple host -- e.g. ARM64 Linux -- would
+    // be undercounted, but that is not a platform this engine ships on.)
     int n = (int) std::thread::hardware_concurrency() / 2;
     return n > 0 ? n : 1;
+}
+
+// GGML CPU thread count: an embedder override (ace_backend_configure), otherwise
+// the auto physical-core count. ace_resolve_threads() (backend-config.h) holds the
+// shared policy: an explicit override is trusted -- an embedder may deliberately
+// spend all cores including the E-cores -- and only clamped to the logical CPU count
+// (ace_logical_cpus(), the same source the MP3 path uses) so an absurd value cannot
+// ask GGML to spawn that many threads. The one-thread-per-physical-core reasoning is
+// the default's (backend_cpu_auto_threads); an explicit request overrides it.
+static int backend_cpu_n_threads(void) {
+    return ace_resolve_threads(ace_backend_config().n_threads, ace_logical_cpus(), backend_cpu_auto_threads());
 }
 
 // Standalone CPU backend via Registry API (DL-safe, no ggml-cpu.h needed).
@@ -103,17 +146,24 @@ static BackendPair backend_init(const char * label) {
     ggml_backend_load_all();
     BackendPair bp = {};
 
-    // GGML_BACKEND env var: force a specific device instead of auto-best.
+    // Device selection: an explicit ace_backend_configure() wins, then the
+    // GGML_BACKEND env var (the CLI fallback), then auto-best below.
     // Device names: CUDA0, Vulkan0, CPU, BLAS (see ggml_backend_dev_name).
-    const char * force_backend = std::getenv("GGML_BACKEND");
-    if (force_backend) {
+    // An *empty* value from either source (config device "" or GGML_BACKEND="")
+    // reads as unset and falls through to auto-best -- the `force_backend[0]`
+    // guard -- by design; only a non-empty, unknown name is a hard error.
+    const std::string & cfg_device    = ace_backend_config().device;
+    const bool          from_config   = !cfg_device.empty();
+    const char *        force_backend = from_config ? cfg_device.c_str() : std::getenv("GGML_BACKEND");
+    if (force_backend && force_backend[0]) {
         bp.backend = ggml_backend_init_by_name(force_backend, nullptr);
         if (!bp.backend) {
-            fprintf(stderr, "[Load] FATAL: GGML_BACKEND=%s not found. Available:", force_backend);
+            std::string avail;
             for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
-                fprintf(stderr, " %s", ggml_backend_dev_name(ggml_backend_dev_get(i)));
+                avail += std::string(" ") + ggml_backend_dev_name(ggml_backend_dev_get(i));
             }
-            fprintf(stderr, "\n");
+            fprintf(stderr, "[Load] FATAL: backend '%s' (from %s) not found. Available:%s\n", force_backend,
+                    from_config ? "ace_backend_configure" : "GGML_BACKEND", avail.c_str());
             exit(1);
         }
     } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,9 @@
+# test-backend-config: explicit thread count + device selection (#19). Includes
+# backend.h, so it links the ggml backends.
+add_executable(test-backend-config test-backend-config.cpp)
+target_link_libraries(test-backend-config PRIVATE acestep-core)
+link_ggml_backends(test-backend-config)
+
 # test-philox: Philox RNG reference dumper.
 add_executable(test-philox test-philox.cpp)
 target_include_directories(test-philox PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/tests/test-backend-config.cpp
+++ b/tests/test-backend-config.cpp
@@ -1,0 +1,119 @@
+// test-backend-config: explicit CPU thread count and device selection (#19).
+//
+// Verifies the embedder-facing contract: ace_backend_configure() sets the thread
+// count and device before first use, backend_cpu_n_threads() honours an explicit
+// override (clamped to the logical CPU count) and otherwise auto-picks a positive
+// default, and clearing the config restores auto. All thread values here are
+// relative to this host's logical CPU count so the test passes on any machine.
+#include "backend.h"
+
+#include <cstdio>
+#include <cstring>           // strcmp
+#include <thread>            // hardware_concurrency
+#ifdef __APPLE__
+#    include <sys/sysctl.h>  // sysctlbyname
+#endif
+
+static int failures = 0;
+
+#define CHECK(cond)                                                         \
+    do {                                                                    \
+        if (!(cond)) {                                                      \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+            failures++;                                                     \
+        }                                                                   \
+    } while (0)
+
+int main() {
+    const int hw = (int) std::thread::hardware_concurrency();
+    const int t2 = hw >= 2 ? 2 : 1;  // a second in-range thread value
+
+    // ace_logical_cpus(): the shared logical-CPU reference both paths clamp against.
+    // >= 1 always, and equal to hardware_concurrency() whenever that reports a value.
+    CHECK(ace_logical_cpus() >= 1);
+    if (hw > 0) {
+        CHECK(ace_logical_cpus() == hw);
+    }
+
+    // Auto by default: a positive thread count, no forced device, never more than
+    // the logical CPUs.
+    CHECK(ace_backend_config().device.empty());
+    const int auto_threads = backend_cpu_n_threads();
+    CHECK(auto_threads > 0);
+    if (hw > 0) {
+        CHECK(auto_threads <= hw);
+    }
+
+    // An explicit count within [1, logical CPUs] is honoured exactly.
+    ace_backend_configure(nullptr, 1);
+    CHECK(backend_cpu_n_threads() == 1);
+    ace_backend_configure(nullptr, t2);
+    CHECK(backend_cpu_n_threads() == t2);
+    if (hw > 0) {
+        ace_backend_configure(nullptr, hw);  // exactly the ceiling
+        CHECK(backend_cpu_n_threads() == hw);
+        // Over the ceiling -- including an absurd value -- is clamped to it, not
+        // passed through to spawn that many workers.
+        ace_backend_configure(nullptr, hw + 100);
+        CHECK(backend_cpu_n_threads() == hw);
+        ace_backend_configure(nullptr, 100000);
+        CHECK(backend_cpu_n_threads() == hw);
+    }
+
+    // <= 0 means auto again -- the positive default.
+    ace_backend_configure(nullptr, 0);
+    CHECK(backend_cpu_n_threads() == auto_threads);
+    ace_backend_configure(nullptr, -4);
+    CHECK(backend_cpu_n_threads() == auto_threads);
+
+    // ace_resolve_threads(): the shared clamp policy that both backend_cpu_n_threads
+    // (backend.h) and the MP3 encoder (audio-io.h) route through. Pure arithmetic, so
+    // these exact values hold on any host regardless of its real core count.
+    CHECK(ace_resolve_threads(0, 10, 8) == 8);        // <= 0 -> the caller's auto default
+    CHECK(ace_resolve_threads(-1, 10, 8) == 8);       // negative -> auto too
+    CHECK(ace_resolve_threads(4, 10, 8) == 4);        // in range -> honoured exactly
+    CHECK(ace_resolve_threads(10, 10, 8) == 10);      // at the ceiling -> honoured
+    CHECK(ace_resolve_threads(100000, 10, 8) == 10);  // absurd -> clamped to hw
+    // hw undetectable (0): the ceiling falls back to the auto count, so an absurd
+    // value is still clamped and the result never drops below 1.
+    CHECK(ace_resolve_threads(100000, 0, 8) == 8);
+    CHECK(ace_resolve_threads(0, 0, 8) == 8);
+    CHECK(ace_resolve_threads(100000, 0, 0) == 1);  // no info at all -> at least 1
+    CHECK(ace_resolve_threads(0, 0, 0) == 1);
+
+    // The device is settable and cleared by "" / NULL.
+    ace_backend_configure("Metal", 0);
+    CHECK(ace_backend_config().device == "Metal");
+    ace_backend_configure(nullptr, 0);
+    CHECK(ace_backend_config().device.empty());
+
+    // The single-field setters change one field without disturbing the other.
+    ace_backend_set_device("Metal");
+    ace_backend_set_threads(1);
+    CHECK(ace_backend_config().device == "Metal");
+    CHECK(backend_cpu_n_threads() == 1);
+    ace_backend_set_threads(t2);  // device untouched
+    CHECK(ace_backend_config().device == "Metal");
+    CHECK(backend_cpu_n_threads() == t2);
+    ace_backend_set_device(nullptr);  // threads untouched
+    CHECK(ace_backend_config().device.empty());
+    CHECK(backend_cpu_n_threads() == t2);
+    ace_backend_configure(nullptr, 0);  // reset both
+
+    // End-to-end: a configured device actually drives backend_init's selection.
+    // "CPU" is always available, so this needs no GPU.
+    ace_backend_configure("CPU", 1);
+    BackendPair bp = backend_init("test");
+    CHECK(bp.backend != nullptr);
+    CHECK(strcmp(ggml_backend_name(bp.backend), "CPU") == 0);
+    CHECK(!bp.has_gpu);
+    backend_release(bp.backend, bp.cpu_backend);
+    ace_backend_configure(nullptr, 0);
+
+    if (failures == 0) {
+        printf("test-backend-config: all checks passed (auto threads = %d, logical = %d)\n", auto_threads, hw);
+        return 0;
+    }
+    fprintf(stderr, "test-backend-config: %d check(s) failed\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Last of four small embedder patches from [Cadenza](https://github.com/erichchampion/cadenza-audio) (independent of the other three).

## What it does

An embedder today can only steer GGML through the `GGML_BACKEND` environment variable, and cannot pick a thread count at all. Environment variables are the wrong interface for an app: a GUI cannot ask its user to export one before launch, and a mobile app has no shell at all.

This adds `src/backend-config.h`: a set-once, unsynchronized configuration object --

```cpp
ace_backend_configure(/*device*/ "Metal", /*n_threads*/ 4);   // both at once
ace_backend_set_device(...); ace_backend_set_threads(...);     // or one field
```

-- that backend init reads before its first model load:

- `NULL`/`""` device means exactly today's behaviour (`GGML_BACKEND` env var, then auto-best), so the CLIs are unchanged.
- A positive thread count caps GGML inference threads; `<= 0` keeps the auto default.
- The device name is one ggml registers; a request that matches nothing dies with the available names printed -- and the message says whether the request came from the config API or the env var, so a misconfigured embedder is not sent debugging the wrong knob.
- The override is clamped to the logical CPU count (preferring Apple's `perflevel0.physicalcpu` where available, since GEMM shares SIMD units across hyperthreads), and the MP3 export encoder honours the same cap through one shared clamp helper so the two workloads cannot diverge.

## Testing

`tests/test-backend-config.cpp` covers config read-back, clamping, and end-to-end device selection against the real registry (Metal on an Apple-silicon Mac, plus the CPU path). Built and run on macOS/arm64/Metal.