### PR TITLE
docs: scope audio-io's planar claim; name the interleaved neighbours

### DIFF
--- a/src/audio-io.h
+++ b/src/audio-io.h
@@ -2,8 +2,12 @@
 // audio-io.h: unified audio read/write for WAV and MP3.
 // Reads any WAV (PCM16/float32, mono/stereo, any rate) or MP3.
 // Writes WAV (16-bit PCM) or MP3 (via mp3enc).
-// All functions use planar stereo float: [L: T samples][R: T samples].
-// Part of acestep.cpp. MIT license.
+// Functions in THIS header return planar stereo float: [L: T samples][R:
+// T samples]. Two neighbours are deliberately different, so check which side
+// of the boundary you are on: wav.h's raw reader returns interleaved (it is
+// deinterleaved on read), and the synthesis pipeline's src/ref input takes
+// time-major interleaved -- while the pipeline's AceAudio output is planar,
+// like this header's returns. Part of acestep.cpp. MIT license.
 
 #include "task-types.h"
 

--- a/src/audio-io.h
+++ b/src/audio-io.h
@@ -4,9 +4,10 @@
 // Writes WAV (16-bit PCM) or MP3 (via mp3enc).
 // Functions in THIS header return planar stereo float: [L: T samples][R:
 // T samples]. Two neighbours are deliberately different, so check which side
-// of the boundary you are on: wav.h's raw reader returns interleaved (it is
-// deinterleaved on read), and the synthesis pipeline's src/ref input takes
-// time-major interleaved -- while the pipeline's AceAudio output is planar,
+// of the boundary you are on: wav.h's raw reader returns time-major
+// interleaved stereo; the helpers in this header deinterleave it to planar on
+// read, and the synthesis pipeline's src/ref input takes time-major
+// interleaved stereo -- while the pipeline's AceAudio output is planar,
 // like this header's returns. Part of acestep.cpp. MIT license.
 
 #include "task-types.h"


### PR DESCRIPTION
A documentation-only patch, found while wiring an embedder's audio path through `ace_synth_job_run_dit`.

`audio-io.h`'s header line says "All functions use planar stereo float". That is accurate about *this header's own returns*, but read alone it invites exactly the planar/interleaved mixup that destroys stereo:

- `wav.h`'s raw reader returns **interleaved** (deinterleaved on read by this header);
- the synthesis pipeline's `src_audio` / `ref_audio` input takes **time-major interleaved** (`vae_enc_compute` indexes `audio[t * 2 + c]`);
- the pipeline's `AceAudio` output is **planar**, like this header's returns.

An embedder that takes the blanket claim as "everything here is planar" feeds `audio_read_48k`'s planar output straight into `src_audio` and gets the two channels smeared into each other — plausible-looking wrong audio, no error, no crash. (We measured it: a correct-layout round trip correlates each output channel with its own input at ~0.997 and cross-channel at ~0.01; a smeared layout collapses that separation.)

This patch scopes the planar claim to this header and names the two interleaved neighbours. No code change; comments only.

Also filed on our side: a round-trip test pinning the layout contract (`test-audio-layout` on our `cadenza` branch) — happy to offer it here too if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that WAV reading provides time-major, interleaved stereo data at the raw reader level.
  - Documented that the associated audio helpers convert stereo data to planar format when reading.
  - Removed contradictory wording about the deinterleaving behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->